### PR TITLE
Make EBA build with a modern OCaml ecosystem

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+*~
+*.orig
+_build
+_trash
+_try
+
+bin/
+_tmp/
+
+src/.merlin
+.DS_Store

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 
 all:
 	mkdir -p bin
-	jbuilder build src/eba.exe
+	dune build src/eba.exe
 	cp _build/default/src/eba.exe bin/eba
 
 clean:
-	jbuilder clean
+	dune clean

--- a/dune-project
+++ b/dune-project
@@ -1,0 +1,2 @@
+(lang dune 1.0)
+(name eba)

--- a/eba.opam
+++ b/eba.opam
@@ -17,7 +17,7 @@ depends: [
     "ocamlgraph"
     "smart-print"
     "cmdliner"
-    "dolog"
+    "dolog" {>= "4.0.0"}
     "fpath"
     ]
 available: [ ocaml-version >= "4.01"]

--- a/eba.opam
+++ b/eba.opam
@@ -8,10 +8,10 @@ bug-reports: "https://github.com/IagoAbal/eba/issues"
 dev-repo: "git://github.com/IagoAbal/eba/"
 license: "BSD3"
 build: [
-    ["jbuilder" "build" "-p" name "-j" jobs]
+    ["dune" "build" "-p" name "-j" jobs]
 ]
 depends: [
-    "jbuilder" {build}
+    "dune" {build}
     "batteries"
     "cil" {= "1.7.4-eba"}
     "ocamlgraph"
@@ -20,4 +20,3 @@ depends: [
     "dolog" {>= "4.0.0"}
     "fpath"
     ]
-available: [ ocaml-version >= "4.01"]

--- a/src/abs.ml
+++ b/src/abs.ml
@@ -1,5 +1,6 @@
 
 open Batteries
+open Dolog
 
 open Type
 

--- a/src/cilExtra.ml
+++ b/src/cilExtra.ml
@@ -1,6 +1,4 @@
-
 open Batteries
-
 open Cil
 
 (* TODO: We can also negate Le, Ge, Lt and Gt *)
@@ -42,7 +40,7 @@ let arg_is_linux_lock e :bool =
 	| TPtr (TComp(ci,_),_)
 	(* THINK: more? *)
 	when ci.cname = "spinlock" || ci.cname = "mutex" -> true
-	| ty ->
+	| _ ->
 		false
 
 let find_arg_in_call pick instrs : exp option =
@@ -178,7 +176,7 @@ let equal_offset exp1 exp2 =
 let is_labeled_with prefix node :bool =
 	node.labels |> List.exists (function
 	| Label(n,_,false) -> String.starts_with n prefix
-	| x -> false
+	| _ -> false
 	)
 
 let is_labeled_while_continue = is_labeled_with "while_continue"

--- a/src/dune
+++ b/src/dune
@@ -1,0 +1,8 @@
+(executable
+ (name eba)
+ (package eba)
+ (public_name eba)
+ (libraries batteries cil ocamlgraph smart_print cmdliner dolog fpath))
+(env
+  (_
+    (flags (:standard -warn-error -A))))

--- a/src/eba.ml
+++ b/src/eba.ml
@@ -1,6 +1,7 @@
 
 open Batteries
 open Cmdliner
+open Dolog
 
 open Abs
 

--- a/src/flow2Checker.ml
+++ b/src/flow2Checker.ml
@@ -3,6 +3,7 @@
  *)
 
 open Batteries
+open Dolog
 
 module Opts = Opts.Get
 

--- a/src/infer.ml
+++ b/src/infer.ml
@@ -2,6 +2,7 @@ module Opts = Opts.Get
 
 open Batteries
 open Type
+open Dolog
 
 open Shape
 open Abs
@@ -279,7 +280,7 @@ let of_instr fnAbs (env :Env.t)
 let of_instr_log fnAbs env instr =
 	let loc = Cil.get_instrLoc instr in
 	let f, k = of_instr fnAbs env instr in
-	 Log.debug "Instr effects:\n %s -> %s\n: %s"
+	Log.debug "Instr effects:\n %s -> %s\n: %s"
 		   (Utils.Location.to_string loc)
 		   (Effects.to_string f)
 		   (Utils.string_of_cil Cil.d_instr instr);

--- a/src/jbuild
+++ b/src/jbuild
@@ -1,7 +1,0 @@
-(jbuild_version 1)
-
-(executable
- ((name eba)
-  (package eba)
-  (public_name eba)
-  (libraries (batteries cil ocamlgraph smart_print cmdliner dolog fpath))))

--- a/src/lenv.ml
+++ b/src/lenv.ml
@@ -1,6 +1,7 @@
 (* FUTURE: Common interface, but several implementations with different trade-offs. *)
 
 open Batteries
+open Dolog
 
 open Type
 open Abs

--- a/src/pathTree.ml
+++ b/src/pathTree.ml
@@ -15,6 +15,7 @@
  *)
 
 open Batteries
+open Dolog
 
 open Type
 open Abs

--- a/src/structs.ml
+++ b/src/structs.ml
@@ -1,4 +1,3 @@
-
 open Batteries
 open Dolog 
 

--- a/src/structs.ml
+++ b/src/structs.ml
@@ -1,5 +1,6 @@
 
 open Batteries
+open Dolog 
 
 (* Dependency Graph *)
 module Dep = struct

--- a/src/type.ml
+++ b/src/type.ml
@@ -1,6 +1,7 @@
 module Opts = Opts.Get
 
 open Batteries
+open Dolog
 
 (* THINK: Maybe encapsulate this into a Name module *)
 type name = string


### PR DESCRIPTION
`jbuilder` is deprecated and `dune` should be used instead. 
This PR updates the build configuration to reflect that while also updating the `Dolog` module. 