### PR TITLE
Update Dolog version

### DIFF
--- a/eba.opam
+++ b/eba.opam
@@ -17,7 +17,7 @@ depends: [
     "ocamlgraph"
     "smart-print"
     "cmdliner"
-    "dolog"
+    "dolog" {>= "4.0.0"}
     "fpath"
     ]
 available: [ ocaml-version >= "4.01"]

--- a/src/abs.ml
+++ b/src/abs.ml
@@ -1,5 +1,6 @@
 
 open Batteries
+open Dolog
 
 open Type
 

--- a/src/eba.ml
+++ b/src/eba.ml
@@ -1,6 +1,7 @@
 
 open Batteries
 open Cmdliner
+open Dolog
 
 open Abs
 

--- a/src/flow2Checker.ml
+++ b/src/flow2Checker.ml
@@ -3,6 +3,7 @@
  *)
 
 open Batteries
+open Dolog
 
 module Opts = Opts.Get
 

--- a/src/infer.ml
+++ b/src/infer.ml
@@ -2,6 +2,7 @@ module Opts = Opts.Get
 
 open Batteries
 open Type
+open Dolog
 
 open Shape
 open Abs
@@ -279,7 +280,7 @@ let of_instr fnAbs (env :Env.t)
 let of_instr_log fnAbs env instr =
 	let loc = Cil.get_instrLoc instr in
 	let f, k = of_instr fnAbs env instr in
-	 Log.debug "Instr effects:\n %s -> %s\n: %s"
+	Log.debug "Instr effects:\n %s -> %s\n: %s"
 		   (Utils.Location.to_string loc)
 		   (Effects.to_string f)
 		   (Utils.string_of_cil Cil.d_instr instr);

--- a/src/lenv.ml
+++ b/src/lenv.ml
@@ -1,6 +1,7 @@
 (* FUTURE: Common interface, but several implementations with different trade-offs. *)
 
 open Batteries
+open Dolog
 
 open Type
 open Abs

--- a/src/pathTree.ml
+++ b/src/pathTree.ml
@@ -15,6 +15,7 @@
  *)
 
 open Batteries
+open Dolog
 
 open Type
 open Abs

--- a/src/structs.ml
+++ b/src/structs.ml
@@ -1,5 +1,6 @@
 
 open Batteries
+open Dolog 
 
 (* Dependency Graph *)
 module Dep = struct

--- a/src/type.ml
+++ b/src/type.ml
@@ -1,6 +1,7 @@
 module Opts = Opts.Get
 
 open Batteries
+open Dolog
 
 (* THINK: Maybe encapsulate this into a Name module *)
 type name = string


### PR DESCRIPTION
This PR updates the `Dolog` version to >= 4.0.0 in order to build on recent OCaml versions. 

`Log` has been moved to `Dolog.Log` as described in https://github.com/UnixJunkie/dolog/blob/master/src/example.ml  